### PR TITLE
thumbnail cache

### DIFF
--- a/AssetIcons/AssetIcons.csproj
+++ b/AssetIcons/AssetIcons.csproj
@@ -53,4 +53,14 @@
     <EmbeddedResource Include="Assets\SelectFilter.png" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ProjectExtensions>
+    <MonoDevelop>
+      <Properties>
+        <Policies>
+          <TextStylePolicy inheritsSet="VisualStudio" inheritsScope="text/plain" scope="text/x-csharp" />
+          <CSharpFormattingPolicy IndentSwitchBody="True" IndentBlocksInsideExpressions="True" AnonymousMethodBraceStyle="NextLine" PropertyBraceStyle="NextLine" PropertyGetBraceStyle="NextLine" PropertySetBraceStyle="NextLine" EventBraceStyle="NextLine" EventAddBraceStyle="NextLine" EventRemoveBraceStyle="NextLine" StatementBraceStyle="NextLine" ElseNewLinePlacement="NewLine" CatchNewLinePlacement="NewLine" FinallyNewLinePlacement="NewLine" WhileNewLinePlacement="DoNotCare" ArrayInitializerWrapping="DoNotChange" ArrayInitializerBraceStyle="NextLine" BeforeMethodDeclarationParentheses="False" BeforeMethodCallParentheses="False" BeforeConstructorDeclarationParentheses="False" NewLineBeforeConstructorInitializerColon="NewLine" NewLineAfterConstructorInitializerColon="SameLine" BeforeDelegateDeclarationParentheses="False" NewParentheses="False" SpacesBeforeBrackets="False" inheritsSet="Mono" inheritsScope="text/x-csharp" scope="text/x-csharp" />
+        </Policies>
+      </Properties>
+    </MonoDevelop>
+  </ProjectExtensions>
 </Project>

--- a/AssetIcons/AssetIcons.csproj
+++ b/AssetIcons/AssetIcons.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>AssetIcons</RootNamespace>
     <AssemblyName>AssetIcons</AssemblyName>
-    <TargetFrameworkVersion>v3.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -28,18 +28,17 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
     <Reference Include="Assembly-CSharp">
-      <HintPath>E:\Gaming\SteamLibrary\steamapps\common\Cities_Skylines\Cities_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files %28x86%29\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="ColossalManaged">
-      <HintPath>E:\Gaming\SteamLibrary\steamapps\common\Cities_Skylines\Cities_Data\Managed\ColossalManaged.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files %28x86%29\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\ColossalManaged.dll</HintPath>
     </Reference>
     <Reference Include="ICities">
-      <HintPath>E:\Gaming\SteamLibrary\steamapps\common\Cities_Skylines\Cities_Data\Managed\ICities.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files %28x86%29\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\ICities.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>E:\Gaming\SteamLibrary\steamapps\common\Cities_Skylines\Cities_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files %28x86%29\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/AssetIcons/IconModifier.cs
+++ b/AssetIcons/IconModifier.cs
@@ -34,15 +34,20 @@ namespace AssetIcons
             var thumbnails = new Dictionary<string, Package.Asset>();
             var tooltips = new Dictionary<string, Package.Asset>();
 
-            foreach (Package package in PackageManager.allPackages) {
-                foreach (Package.Asset asset in package) {
-                    if (asset.type == UserAssetType.CustomAssetMetaData) {
+            foreach (Package package in PackageManager.allPackages)
+            {
+                foreach (Package.Asset asset in package)
+                {
+                    if (asset.type == UserAssetType.CustomAssetMetaData)
+                    {
                         CustomAssetMetaData md = asset.Instantiate<CustomAssetMetaData>();
-                        if (md.imageRef != null && !thumbnails.ContainsKey(package.packageName)) {
+                        if (md.imageRef != null && !thumbnails.ContainsKey(package.packageName))
+                        {
                             md.imageRef.Cache();
                             thumbnails.Add(package.packageName, md.imageRef);
                         }
-                        if (md.steamPreviewRef != null && !tooltips.ContainsKey(package.packageName)) {
+                        if (md.steamPreviewRef != null && !tooltips.ContainsKey(package.packageName))
+                        {
                             md.steamPreviewRef.Cache();
                             tooltips.Add(package.packageName, md.steamPreviewRef);
                         }
@@ -52,7 +57,8 @@ namespace AssetIcons
 
             // Now go through all BuildingInfos and patch their icons.
             int infoCount = PrefabCollection<BuildingInfo>.LoadedCount();
-            for (uint infoIndex = 0; infoIndex < infoCount; ++infoIndex) {
+            for (uint infoIndex = 0; infoIndex < infoCount; ++infoIndex)
+            {
                 BuildingInfo info = PrefabCollection<BuildingInfo>.GetLoaded(infoIndex);
                 Texture2D thumbnailTexture = null;
                 Texture2D tooltipTexture = null;
@@ -61,44 +67,57 @@ namespace AssetIcons
                 // TODO: Item has a thumnail, apply color correction. Should the color corrected thumbnail be cached?
                 UIButton uiButton = null;
                 GameObject gameObject = GameObject.Find(info.name);
-                if (gameObject != null) {
+                if (gameObject != null)
+                {
                     uiButton = gameObject.GetComponent<UIButton>();
                 }
-                if (!string.IsNullOrEmpty(info.m_Thumbnail)) {
+                if (!string.IsNullOrEmpty(info.m_Thumbnail))
+                {
                     // This item has a thumbnail, check if it's a generated one.
-                    if (uiButton != null && uiButton.atlas != null) {
+                    if (uiButton != null && uiButton.atlas != null)
+                    {
                         uiButton = gameObject.GetComponent<UIButton>();
 
                         // TODO: should this be optimized as well?
-                        if (uiButton != null && uiButton.atlas != null) {
+                        if (uiButton != null && uiButton.atlas != null)
+                        {
                             var focusedSpriteInfo = uiButton.atlas[uiButton.focusedFgSprite];
-                            if (focusedSpriteInfo != null && focusedSpriteInfo.texture != null) {
+                            if (focusedSpriteInfo != null && focusedSpriteInfo.texture != null)
+                            {
                                 long nonBlueCount = 0;
-                                try {
+                                try
+                                {
                                     Color32[] focusedPixels = focusedSpriteInfo.texture.GetPixels32();
                                     // The default atlas generator creates ugly dark blue focused icons
                                     // by removing everything from the red and green channel.  Detect these
                                     // by adding up the amount of red and green in the image.
-                                    foreach (Color32 pixel in focusedPixels) {
-                                        if (pixel.a > 32) {
+                                    foreach (Color32 pixel in focusedPixels)
+                                    {
+                                        if (pixel.a > 32)
+                                        {
                                             nonBlueCount += pixel.r + pixel.g;
                                         }
                                     }
-                                } catch (Exception) {
+                                }
+                                catch (Exception)
+                                {
                                     Debug.Log(String.Format("Failed to patch texture for {0}, skipping.", info.name));
                                     continue;
                                 }
 
-                                if (nonBlueCount < 10000) {
+                                if (nonBlueCount < 10000)
+                                {
                                     // This is a generated atlas.  Replace the focused icon by generating
                                     // a new atlas.  Include the tooltip if there is one.
                                     var thumbnailSpriteInfo = uiButton.atlas[uiButton.normalFgSprite];
-                                    if (thumbnailSpriteInfo != null && thumbnailSpriteInfo.texture != null) {
+                                    if (thumbnailSpriteInfo != null && thumbnailSpriteInfo.texture != null)
+                                    {
                                         thumbnailTexture = thumbnailSpriteInfo.texture;
                                         thumbnailTexture.name = info.name + "Icon";
                                     }
                                     var tooltipSpriteInfo = uiButton.atlas["tooltip"];
-                                    if (tooltipSpriteInfo != null && thumbnailSpriteInfo.texture != null) {
+                                    if (tooltipSpriteInfo != null && thumbnailSpriteInfo.texture != null)
+                                    {
                                         tooltipTexture = tooltipSpriteInfo.texture;
                                         tooltipTexture.name = info.name;
                                     }
@@ -111,16 +130,22 @@ namespace AssetIcons
                 // TODO: check if thumbnail is cached, if it is assign it to info.info_mThumbnail
                 // Process steam workshop image if thumbnail not cached.
                 // Create a thumbnail based on the steam workshop image.
-                if (string.IsNullOrEmpty(info.m_Thumbnail) && thumbnails.ContainsKey(packageName)) {
-                    if (!LoadTexture(packageName, ref thumbnailTexture)) {
+                if (string.IsNullOrEmpty(info.m_Thumbnail) && thumbnails.ContainsKey(packageName))
+                {
+                    if (!LoadTexture(packageName, ref thumbnailTexture))
+                    {
                         // TODO: what does Instantiate do?
                         thumbnailTexture = thumbnails[packageName].Instantiate<Texture2D>();
-                        if (thumbnailTexture != null) {
+                        if (thumbnailTexture != null)
+                        {
                             thumbnailTexture.wrapMode = TextureWrapMode.Clamp;
                             thumbnailTexture.name = info.name + "Icon";
-                            if (thumbnailTexture.width > thumbnailTexture.height) {
+                            if (thumbnailTexture.width > thumbnailTexture.height)
+                            {
                                 ScaleTexture(thumbnailTexture, THUMBNAIL_SIZE, (THUMBNAIL_SIZE * thumbnailTexture.height) / thumbnailTexture.width);
-                            } else {
+                            }
+                            else
+                            {
                                 ScaleTexture(thumbnailTexture, (THUMBNAIL_SIZE * thumbnailTexture.width) / thumbnailTexture.height, THUMBNAIL_SIZE);
                             }
                         }
@@ -130,25 +155,33 @@ namespace AssetIcons
                 // TODO: check if tooltip thumbnail is cached, if it is assign it to info.m_InfoTooltipThumbnail
                 // Process steam workshop image if tooltip thumbnail not cached.
                 // Create a tooltip image based on the steam workshop image.
-                if (string.IsNullOrEmpty(info.m_InfoTooltipThumbnail) && tooltips.ContainsKey(packageName)) {
+                if (string.IsNullOrEmpty(info.m_InfoTooltipThumbnail) && tooltips.ContainsKey(packageName))
+                {
                     // Note: clamp and wrap mode not set for tooltip.
-                    if (!LoadTexture(packageName, ref tooltipTexture)) {
+                    if (!LoadTexture(packageName, ref tooltipTexture))
+                    {
                         tooltipTexture = tooltips[packageName].Instantiate<Texture2D>();
-                        if (tooltipTexture != null) {
+                        if (tooltipTexture != null)
+                        {
                             // The tooltip texture name must match the info name, as that's the key value that's used
                             // (stored on UIButton.m_Tooltip, not by us).
                             tooltipTexture.name = info.name;
 
                             // Crop and scale the tooltip to TOOLTIP_WIDTH x TOOLTIP_HEIGHT
-                            if (((float)tooltipTexture.width / (float)tooltipTexture.height) > (float)TOOLTIP_WIDTH / (float)TOOLTIP_HEIGHT) {
+                            if (((float)tooltipTexture.width / (float)tooltipTexture.height) > (float)TOOLTIP_WIDTH / (float)TOOLTIP_HEIGHT)
+                            {
                                 // Picture is too wide, scale to TOOLTIP_HEIGHT pixels tall and then crop out the middle
                                 ScaleTexture(tooltipTexture, (TOOLTIP_HEIGHT * tooltipTexture.width) / tooltipTexture.height, TOOLTIP_HEIGHT);
                                 CropTexture(tooltipTexture, (tooltipTexture.width - TOOLTIP_WIDTH) / 2, 0, TOOLTIP_WIDTH, TOOLTIP_HEIGHT);
-                            } else if (((float)tooltipTexture.width / (float)tooltipTexture.height) < (float)TOOLTIP_WIDTH / (float)TOOLTIP_HEIGHT) {
+                            }
+                            else if (((float)tooltipTexture.width / (float)tooltipTexture.height) < (float)TOOLTIP_WIDTH / (float)TOOLTIP_HEIGHT)
+                            {
                                 // Picture is too tall, scale to TOOLTIP_WIDTH pixels wide and then crop out the middle
                                 ScaleTexture(tooltipTexture, TOOLTIP_WIDTH, (TOOLTIP_WIDTH * tooltipTexture.height) / tooltipTexture.width);
                                 CropTexture(tooltipTexture, 0, (tooltipTexture.height - TOOLTIP_HEIGHT) / 2, TOOLTIP_WIDTH, TOOLTIP_HEIGHT);
-                            } else {
+                            }
+                            else
+                            {
                                 // Picture is the right aspect ratio, just scale it
                                 ScaleTexture(tooltipTexture, TOOLTIP_WIDTH, TOOLTIP_HEIGHT);
                             }
@@ -160,16 +193,24 @@ namespace AssetIcons
                 // No modifications needed in this method below this line.
                 // Build these textures into an atlas.
                 Texture2D[] textures;
-                if (thumbnailTexture != null) {
-                    if (tooltipTexture != null) {
+                if (thumbnailTexture != null)
+                {
+                    if (tooltipTexture != null)
+                    {
                         textures = new Texture2D[] { thumbnailTexture, null, null, null, null, tooltipTexture };
-                    } else {
+                    }
+                    else
+                    {
                         textures = new Texture2D[] { thumbnailTexture, null, null, null, null };
                     }
                     GenerateMissingThumbnailVariants(ref textures);
-                } else if (tooltipTexture != null) {
+                }
+                else if (tooltipTexture != null)
+                {
                     textures = new Texture2D[] { tooltipTexture };
-                } else {
+                }
+                else
+                {
                     // Hmm, we've failed to make any textures.  Move on to the next BuildingInfo.
                     continue;
                 }
@@ -179,9 +220,11 @@ namespace AssetIcons
 
                 UITextureAtlas atlas = AssetImporterThumbnails.CreateThumbnailAtlas(textures, info.name + "Atlas");
 
-                if (thumbnailTexture != null) {
+                if (thumbnailTexture != null)
+                {
                     // Store the thumbnail atlas and icon names on the uiButton for this building.
-                    if (uiButton != null) {
+                    if (uiButton != null)
+                    {
                         uiButton.atlas = atlas;
 
                         string baseIconName = info.name + "Icon";
@@ -199,7 +242,8 @@ namespace AssetIcons
                     info.m_Thumbnail = info.name + "Icon";
                 }
 
-                if (tooltipTexture != null) {
+                if (tooltipTexture != null)
+                {
                     // Store the tooltip atlas for this building.
                     info.m_InfoTooltipAtlas = atlas;
 
@@ -208,7 +252,8 @@ namespace AssetIcons
                     // existing icons.
                     info.m_InfoTooltipThumbnail = "";
 
-                    if (uiButton != null) {
+                    if (uiButton != null)
+                    {
                         uiButton.tooltip = info.GetLocalizedTooltip();
                     }
                 }
@@ -222,8 +267,10 @@ namespace AssetIcons
         public static void ScaleTexture(Texture2D tex, int width, int height)
         {
             var newPixels = new Color[width * height];
-            for (int y = 0; y < height; ++y) {
-                for (int x = 0; x < width; ++x) {
+            for (int y = 0; y < height; ++y)
+            {
+                for (int x = 0; x < width; ++x)
+                {
                     newPixels[y * width + x] = tex.GetPixelBilinear(((float)x) / width, ((float)y) / height);
                 }
             }
@@ -256,7 +303,8 @@ namespace AssetIcons
         // and generates ugly dark blue focused thumbnails.
         public void GenerateMissingThumbnailVariants(ref Texture2D[] thumbs)
         {
-            if (thumbs[0] == null) {
+            if (thumbs[0] == null)
+            {
                 return;
             }
 
@@ -270,28 +318,32 @@ namespace AssetIcons
             Texture2D disabledTexture = thumbs[4];
             var newPixels = new Color32[baseTexture.width * baseTexture.height];
             var pixels = baseTexture.GetPixels32();
-            if (focusedTexture == null) {
+            if (focusedTexture == null)
+            {
                 ApplyFilter(pixels, newPixels, ColorizeFocused);
                 focusedTexture = new Texture2D(baseTexture.width, baseTexture.height, TextureFormat.ARGB32, false, false);
                 focusedTexture.SetPixels32(newPixels);
                 focusedTexture.Apply(false);
             }
             focusedTexture.name = baseTexture.name + "Focused";
-            if (hoveredTexture == null) {
+            if (hoveredTexture == null)
+            {
                 ApplyFilter(pixels, newPixels, c => new Color32((byte)(128 + c.r / 2), (byte)(128 + c.g / 2), (byte)(128 + c.b / 2), c.a));
                 hoveredTexture = new Texture2D(baseTexture.width, baseTexture.height, TextureFormat.ARGB32, false, false);
                 hoveredTexture.SetPixels32(newPixels);
                 hoveredTexture.Apply(false);
             }
             hoveredTexture.name = baseTexture.name + "Hovered";
-            if (pressedTexture == null) {
+            if (pressedTexture == null)
+            {
                 ApplyFilter(pixels, newPixels, c => new Color32((byte)(192 + c.r / 4), (byte)(192 + c.g / 4), (byte)(192 + c.b / 4), c.a));
                 pressedTexture = new Texture2D(baseTexture.width, baseTexture.height, TextureFormat.ARGB32, false, false);
                 pressedTexture.SetPixels32(newPixels);
                 pressedTexture.Apply(false);
             }
             pressedTexture.name = baseTexture.name + "Pressed";
-            if (disabledTexture == null) {
+            if (disabledTexture == null)
+            {
                 ApplyFilter(pixels, newPixels, c => new Color32(0, 0, 0, c.a));
                 disabledTexture = new Texture2D(baseTexture.width, baseTexture.height, TextureFormat.ARGB32, false, false);
                 disabledTexture.SetPixels32(newPixels);
@@ -305,7 +357,8 @@ namespace AssetIcons
             thumbs[3] = pressedTexture;
             thumbs[4] = disabledTexture;
 
-            for (var i = 1; i <= 4; i++) {
+            for (var i = 1; i <= 4; i++)
+            {
                 SaveTexture(thumbs[i]);
             }
         }
@@ -330,7 +383,8 @@ namespace AssetIcons
 
         private static void ApplyFilter(Color32[] src, Color32[] dst, Filter filter)
         {
-            for (int i = 0; i < src.Length; i++) {
+            for (int i = 0; i < src.Length; i++)
+            {
                 dst[i] = filter(src[i]);
             }
         }


### PR DESCRIPTION
Save generated thumbnail and tooltip icon textures to disk cache in order to speed up loading on subsequent runs.
